### PR TITLE
Add support for all file types including folders

### DIFF
--- a/internal/handlers/ReadFiles.go
+++ b/internal/handlers/ReadFiles.go
@@ -93,9 +93,7 @@ func ReadFilesHanderFromRoot(res http.ResponseWriter, req *http.Request) {
 	var videoFiles []string
 	var supportedExtensions = []string{".MP4", ".MKV", ".JPG", ".JPEG", ".PNG"}
 	for _, file := range files {
-		if file.IsDir() {
-			videoFiles = append(videoFiles, file.Name()+"/")
-		} else {
+		if !file.IsDir() {
 			ext := strings.ToUpper(filepath.Ext(file.Name()))
 			for _, extension := range supportedExtensions {
 				if ext == extension {

--- a/internal/handlers/ReadFiles.go
+++ b/internal/handlers/ReadFiles.go
@@ -56,6 +56,12 @@ func add(x, y int) int {
 
 // check if the string ends with any of the supported extensions
 func hasSupportedExtension(fileName string, _supportedExtensions []string) bool {
+	if fileName == "" {
+		return false
+	}
+	if strings.HasSuffix(fileName, "/") {
+		return true
+	}
 	for _, extension := range _supportedExtensions {
 		if strings.HasSuffix(strings.ToUpper(fileName), extension) {
 			return true
@@ -87,7 +93,9 @@ func ReadFilesHanderFromRoot(res http.ResponseWriter, req *http.Request) {
 	var videoFiles []string
 	var supportedExtensions = []string{".MP4", ".MKV", ".JPG", ".JPEG", ".PNG"}
 	for _, file := range files {
-		if !file.IsDir() {
+		if file.IsDir() {
+			videoFiles = append(videoFiles, file.Name()+"/")
+		} else {
 			ext := strings.ToUpper(filepath.Ext(file.Name()))
 			for _, extension := range supportedExtensions {
 				if ext == extension {


### PR DESCRIPTION
Update `internal/handlers/ReadFiles.go` to support reading all file types including folders.

* Add logic to `hasSupportedExtension` function to include directories.
* Modify `ReadFilesHanderFromRoot` to include directories in the list of files.
* Update `ReadFilesHanderFromRoot` to display directories and files in the inline HTML template.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rajath002/File-Server/pull/7?shareId=19913750-e6a1-4433-ab7e-989239d32c89).